### PR TITLE
Fix the lack of whitespace after the 'catch' keyword

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -6,7 +6,7 @@ export default function parser(content, file) {
   try {
     return yaml.safeLoad(stripJsonComments(content))
   }
-  catch(e) {
+  catch (e) {
     // `(module.)exports` = JS ?
     if (/exports/.test(content)) {
       return evalModule(content)


### PR DESCRIPTION
I ran the npm test , but an error occurred (error  Keyword "catch" must be followed by whitespace). So I fixed a breach of the stylelint configuration.

Does this fix is ​​good ?
